### PR TITLE
Semáforo só é chamado quando o arquivo programa.py é salvo

### DIFF
--- a/2018-02-01/tests.sh
+++ b/2018-02-01/tests.sh
@@ -1,13 +1,26 @@
 #!/bin/sh
 
+DEF_TIME=`stat -c %Z programa.py`
+
 while true
 do
-    sleep 1
-    clear
-    python programa.py
-    if [ "$?" = "0" ]; then
-        http 192.168.12.38/gpio/green > /dev/null
-    else
-        http 192.168.12.38/gpio/red > /dev/null
-    fi
+	MOD_TIME=`stat -c %Z programa.py`
+
+	if [[ "$MOD_TIME" != "$DEF_TIME" ]] 
+	then
+	    #echo "programa.py modified"
+	    python programa.py
+	    
+		if [ "$?" = "0" ]
+	    then
+			#echo "green"
+	    	http 192.168.12.38/gpio/green > /dev/null
+	    else
+			#echo "red"	  	
+			http 19.168.12.38/gpio/red > /dev/null
+	    fi
+	    
+	    DEF_TIME=$MOD_TIME
+	fi
+	sleep 1
 done


### PR DESCRIPTION
Modifiquei o script do semáforo para ser chamado somente quando for modificado, evitando requests desnecessários. Isto deve acalmar o T.O.C. do @mawkee :).

Meu primeiro P.R.. Se tiver muito fora do escopo, desconsidere.